### PR TITLE
feature: add management plane

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ kerlescan = {editable = true,git = "https://github.com/beav/kerlescan.git",ref =
 prometheus-client = "*"
 watchtower = "*"
 flake8 = "*"
+gunicorn = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "31df481f769a925608e36d0de692e72e96310dbb3a006739ce55d9c4387fae6e"
+            "sha256": "764cd10e019bf1441245ac3723b1c5d4a60857cd97c21e5b6769c78cd5e6b227"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -94,6 +94,14 @@
                 "sha256:45eb5a6fd193d6cf7e0cf5d8a5b31f83d5faae0293695626f539a823e93b13f6"
             ],
             "version": "==1.1.1"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626",
+                "sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"
+            ],
+            "index": "pypi",
+            "version": "==20.0.4"
         },
         "idna": {
             "hashes": [

--- a/historical_system_profiles/app.py
+++ b/historical_system_profiles/app.py
@@ -32,6 +32,7 @@ def create_connexion_app():
     connexion_app.add_api(
         "api.spec.yaml", strict_validation=True, validate_responses=True
     )
+    connexion_app.add_api("mgmt_api.spec.yaml")
     flask_app = connexion_app.app
 
     # set up logging ASAP

--- a/historical_system_profiles/mgmt_views/v0.py
+++ b/historical_system_profiles/mgmt_views/v0.py
@@ -1,0 +1,15 @@
+from flask import jsonify
+
+from kerlescan.metrics_registry import get_registry
+
+from prometheus_client import generate_latest
+
+
+def metrics():
+    registry = get_registry()
+    prometheus_data = generate_latest(registry)
+    return prometheus_data
+
+
+def status():
+    return jsonify({"status": "running"})

--- a/historical_system_profiles/openapi/mgmt_api.spec.yaml
+++ b/historical_system_profiles/openapi/mgmt_api.spec.yaml
@@ -1,0 +1,51 @@
+---
+openapi: 3.0.1
+info:
+  version: "0.1"
+  title: Historical System Profiles Backend Service Management Plane
+  description: Management API for Historical System Profiles
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: /mgmt/v0
+
+
+paths:
+  /status:
+    get:
+      summary: health check liveness call
+      operationId: historical_system_profiles.mgmt_views.v0.status
+      tags:
+        - status
+      responses:
+        '200':
+          description: "A small JSON indicating the application is deployed.
+                        This serves as both the liveness and readiness call."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Status"
+  /metrics:
+    get:
+      summary: prometheus metrics
+      operationId: historical_system_profiles.mgmt_views.v0.metrics
+      tags:
+        - prometheus
+      responses:
+        '200':
+          description: "Display metrics needed for Prometheus"
+          content:
+            text/plain:
+              schema:
+                type: string
+
+components:
+  schemas:
+    Status:
+      required:
+        - status
+      properties:
+        status:
+          type: string

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,7 @@
+from historical_system_profiles.app import create_app
+
+application = create_app()
+
+if __name__ == "__main__":
+    application.run()
+


### PR DESCRIPTION
This commit exposes `/mgmt/v0/status` and `/mgmt/v0/metrics`.

The status page simply returns a static "this is running" json, and
the metrics page is currently blank. As metrics are regsitered, it
will fill in.