### PR TITLE
fix: change format of returned profiles for inv id

### DIFF
--- a/historical_system_profiles/openapi/api.spec.yaml
+++ b/historical_system_profiles/openapi/api.spec.yaml
@@ -186,14 +186,8 @@ components:
           type: string
     HistoricalProfilesForSystem:
       required:
-        - inventory_uuid
-        - display_name
         - profiles
       properties:
-        inventory_uuid:
-          type: string
-        display_name:
-          type: string
         profiles:
           type: array
           items:

--- a/historical_system_profiles/views/v0.py
+++ b/historical_system_profiles/views/v0.py
@@ -48,18 +48,10 @@ def get_hsps_by_inventory_id(inventory_id):
     )
 
     query_results = query.all()
-    if len(query_results) == 0:
-        return {"data": []}
-    else:
-        result = {
-            "inventory_uuid": inventory_id,
-            "display_name": query_results[0].system_profile[
-                "display_name"
-            ],  # TODO: pull this from inventory instead of from the first record
-        }
-        profiles = [{"created": p.created_on, "id": p.id} for p in query_results]
-        result["profiles"] = profiles
-        return {"data": [result]}
+    result = {
+        "profiles": [{"created": p.created_on, "id": p.id} for p in query_results],
+    }
+    return {"data": [result]}
 
 
 def create_profile(body):


### PR DESCRIPTION
We previously would send `{"data": []}` if no profiles were found for a
given ID, but would send a more complex data structure if profiles were
found. This ended up requiring two cases to handle the various returned
values.

We now return `{"data": {"profiles": [<profile1>, <profile2>, ...]}}`
every time. If no data is returned, we simply don't populate the
"profiles" list.