### PR TITLE
feature: fetch the most current name for HSPs

### DIFF
--- a/historical_system_profiles/metrics.py
+++ b/historical_system_profiles/metrics.py
@@ -4,3 +4,14 @@ rbac_requests = Histogram("hsp_rbac_service_requests", "rbac service call stats"
 rbac_exceptions = Counter(
     "hsp_rbac_exceptions", "count of exceptions raised by rbac service"
 )
+inventory_requests = Histogram(
+    "hsp_inventory_service_requests", "inventory service call stats"
+)
+inventory_exceptions = Counter(
+    "hsp_inventory_exceptions", "count of exceptions raised by inventory service"
+)
+
+# this metric is not relevant but kerlescan expects it
+inventory_no_sysprofile = Histogram(
+    "drift_systems_compared_no_sysprofile_UNUSED", "unused metric - do not use",
+)

--- a/historical_system_profiles/views/v0.py
+++ b/historical_system_profiles/views/v0.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, request, current_app
 
 from kerlescan import view_helpers
+from kerlescan.inventory_service_interface import fetch_systems_with_profiles
+from kerlescan.service_interface import get_key_from_headers
 
 from historical_system_profiles.models import HistoricalSystemProfile, db
 from historical_system_profiles import metrics
@@ -26,14 +28,30 @@ def get_hsps_by_ids(profile_ids):
         HistoricalSystemProfile.account == account_number,
         HistoricalSystemProfile.id.in_(profile_ids),
     )
-    query_results = query.all()
+    result = query.all()
 
-    result = []
-    for query_result in query_results:
-        historical_sys_profile = query_result
-        result.append(historical_sys_profile.to_json())
+    result_with_updated_names = _get_current_names_for_profiles(result)
 
-    return {"data": result}
+    return {"data": [r.to_json() for r in result_with_updated_names]}
+
+
+def _get_current_names_for_profiles(hsps):
+    # make a unique list of inventory IDs
+    inventory_ids = list({str(h.inventory_id) for h in hsps})
+
+    auth_key = get_key_from_headers(request.headers)
+
+    systems = fetch_systems_with_profiles(
+        inventory_ids, auth_key, current_app.logger, _get_event_counters(),
+    )
+    display_names = {system["id"]: system["display_name"] for system in systems}
+    enriched_hsps = []
+    for hsp in hsps:
+        current_display_name = display_names[str(hsp.inventory_id)]
+        hsp.system_profile["display_name"] = current_display_name
+        enriched_hsps.append(hsp)
+
+    return enriched_hsps
 
 
 def get_hsps_by_inventory_id(inventory_id):
@@ -87,3 +105,14 @@ def ensure_rbac():
         request_metric=metrics.rbac_requests,
         exception_metric=metrics.rbac_exceptions,
     )
+
+
+def _get_event_counters():
+    """
+    small helper to create a dict of event counters
+    """
+    return {
+        "systems_compared_no_sysprofile": metrics.inventory_no_sysprofile,
+        "inventory_service_requests": metrics.inventory_requests,
+        "inventory_service_exceptions": metrics.inventory_exceptions,
+    }

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -54,3 +54,37 @@ HISTORICAL_PROFILE = {
         "id": "bbbbbbbb-28ae-11e9-afd9-c85b761454fa",
     },
 }
+
+FETCH_SYSTEMS_WITH_PROFILES_RESULT = (
+    {
+        "account": "9876543",
+        "bios_uuid": "e380fd4a-28ae-11e9-974c-c85b761454fb",
+        "created": "2018-01-31T13:00:00.100010Z",
+        "display_name": "tartuffe",
+        "fqdn": "hostname_one",
+        "id": "cd54d888-4ccb-11ea-8627-98fa9b07d419",
+        "insights_id": "00000000-28af-11e9-9ab0-c85b761454fa",
+        "ip_addresses": ["10.0.0.3", "2620:52:0:2598:5054:ff:fecd:ae15"],
+        "mac_addresses": ["52:54:00:cd:ae:00", "00:00:00:00:00:00"],
+        "rhel_machine_id": None,
+        "satellite_id": None,
+        "subscription_manager_id": "RHN Classic and Red Hat Subscription Management",
+        "system_profile": {
+            "salutation": "hi",
+            "fqdn": "hostname_one",
+            "system_profile_exists": False,
+            "id": "bbbbbbbb-28ae-11e9-afd9-c85b761454fa",
+            "network_interfaces": [
+                {
+                    "name": "eth99",
+                    "mtu": 3,
+                    "ipv4_addresses": ["8.7.6.5"],
+                    "ipv6_addresses": ["00:00:01"],
+                },
+                {"no_name": "foo"},
+            ],
+        },
+        "tags": [],
+        "updated": "2018-01-31T14:00:00.500000Z",
+    },
+)

--- a/tests/test_v0_api.py
+++ b/tests/test_v0_api.py
@@ -39,7 +39,9 @@ class HSPApiTests(ApiTest):
         self.assertEqual(response.status_code, 400)
         self.assertIn("too short", json.loads(response.data)["detail"])
 
-    def test_valid_post(self):
+    @mock.patch("historical_system_profiles.views.v0.fetch_systems_with_profiles")
+    def test_valid_post(self, mock_fetch_systems):
+        mock_fetch_systems.return_value = fixtures.FETCH_SYSTEMS_WITH_PROFILES_RESULT
         response = self.client.post(
             "/api/historical-system-profiles/v0/profiles",
             json=fixtures.HISTORICAL_PROFILE,
@@ -58,4 +60,9 @@ class HSPApiTests(ApiTest):
             headers=fixtures.AUTH_HEADER,
         )
         fetched_profile = json.loads(response.data)["data"][0]
+        # confirm we have the updated display name from inventory
+        self.assertEqual("tartuffe", fetched_profile["display_name"])
+        # set the display name to the old value so we can compare that no other values changed
+        fetched_profile["system_profile"]["display_name"] = "test-system"
+        fetched_profile["display_name"] = "test-system"
         self.assertEqual(profile, fetched_profile)


### PR DESCRIPTION
Previously, we would send the user the display_name that was used when
the profile was recorded. Instead, we now fetch the current display_name
and use that.

There will be a follow-up PR to not record the display_name in the
first place, since it's now a dynamically created field.