### PR TITLE
feature: use captured_date instead of created_on

### DIFF
--- a/historical_system_profiles/models.py
+++ b/historical_system_profiles/models.py
@@ -32,6 +32,13 @@ class HistoricalSystemProfile(db.Model):
     def display_name(self):
         return self.system_profile["display_name"]
 
+    @property
+    def captured_date(self):
+        if "captured_date" in self.system_profile:
+            return self.system_profile["captured_date"]
+        else:
+            return self.created_on
+
     def to_json(self):
         json_dict = {}
         json_dict["id"] = str(self.id)
@@ -41,4 +48,5 @@ class HistoricalSystemProfile(db.Model):
         json_dict["updated"] = self.modified_on.isoformat() + "Z"
         json_dict["system_profile"] = self.system_profile
         json_dict["display_name"] = self.display_name
+        json_dict["captured_date"] = self.captured_date
         return json_dict

--- a/historical_system_profiles/openapi/api.spec.yaml
+++ b/historical_system_profiles/openapi/api.spec.yaml
@@ -154,6 +154,7 @@ components:
         - inventory_id
         - system_profile
         - updated
+        - captured_date
       properties:
         account:
           type: string
@@ -168,6 +169,8 @@ components:
         system_profile:
           type: object
         updated:
+          type: string
+        captured_date:
           type: string
     Version:
       required:
@@ -192,10 +195,11 @@ components:
           type: array
           items:
             type: object
+            additionalProperties: false
             properties:
               id:
                 type: string
-              created:
+              captured_date:
                 type: string
   parameters:
     InventoryId:

--- a/historical_system_profiles/views/v0.py
+++ b/historical_system_profiles/views/v0.py
@@ -49,7 +49,9 @@ def get_hsps_by_inventory_id(inventory_id):
 
     query_results = query.all()
     result = {
-        "profiles": [{"created": p.created_on, "id": p.id} for p in query_results],
+        "profiles": [
+            {"captured_date": p.captured_date, "id": p.id} for p in query_results
+        ],
     }
     return {"data": [result]}
 


### PR DESCRIPTION
Previously, we displayed the "created" date of the historical record.
This made little sense for end users since they are not interested in
when a record was written to our DB.

Instead, we display "captured_date" which is when the data was
captured on the host system. If the captured date is not found, we
fall back to using the created date for that field.