### PR TITLE
fix: sort list of profiles by captured_date

### DIFF
--- a/historical_system_profiles/views/v0.py
+++ b/historical_system_profiles/views/v0.py
@@ -89,7 +89,8 @@ def get_hsps_by_inventory_id(inventory_id):
             }
         )
 
-    result = {"profiles": profile_metadata}
+    sorted_profile_metadata = sorted(profile_metadata, key=lambda p: p["captured_date"])
+    result = {"profiles": sorted_profile_metadata}
     return {"data": [result]}
 
 


### PR DESCRIPTION
This commit adds a sort when returning profiles for a system.