### PR TITLE
fix: return the return value through wrapper

### DIFF
--- a/historical_system_profiles/app.py
+++ b/historical_system_profiles/app.py
@@ -46,6 +46,8 @@ def create_connexion_app():
 
     # set up DB
     flask_app.config["SQLALCHEMY_ECHO"] = False
+    if config.log_sql_statements:
+        flask_app.config["SQLALCHEMY_ECHO"] = True
     flask_app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     flask_app.config["SQLALCHEMY_DATABASE_URI"] = config.db_uri
     flask_app.config["SQLALCHEMY_POOL_SIZE"] = config.db_pool_size

--- a/historical_system_profiles/config.py
+++ b/historical_system_profiles/config.py
@@ -1,6 +1,8 @@
 import logging
 import os
 
+from kerlescan.config import str_to_bool
+
 # pull the app name from the env var; we are not fully initialized yet
 app_name = os.getenv("APP_NAME", "historical-system-profiles")
 logger = logging.getLogger(app_name)
@@ -35,6 +37,7 @@ aws_access_key_id = os.getenv("CW_AWS_ACCESS_KEY_ID", None)
 aws_secret_access_key = os.getenv("CW_AWS_SECRET_ACCESS_KEY", None)
 aws_region_name = os.getenv("CW_AWS_REGION_NAME", "us-east-1")
 log_group = os.getenv("LOG_GROUP", "platform-dev")
+log_sql_statements = str_to_bool(os.getenv("LOG_SQL_STATEMENTS", "False"))
 namespace = get_namespace()
 
 valid_profile_age_days = float(os.getenv("VALID_PROFILE_AGE_DAYS", 7.0))

--- a/historical_system_profiles/db_interface.py
+++ b/historical_system_profiles/db_interface.py
@@ -13,7 +13,8 @@ def rollback_on_exception(func):
 
     def wrapper_rollback(*args, **kwargs):
         try:
-            func(*args, **kwargs)
+            retval = func(*args, **kwargs)
+            return retval
         except SQLAlchemyError:
             db.session.rollback()
             raise


### PR DESCRIPTION
Previously, our transaction wrapper was invoking the correct method,
but was not returning the return value.

This commit adds a return so the value goes through. This is useful
when you want to know the number of deleted records.