### PR TITLE
set `created_on` when object is instantiated

### DIFF
--- a/historical_system_profiles/models.py
+++ b/historical_system_profiles/models.py
@@ -30,6 +30,8 @@ class HistoricalSystemProfile(db.Model):
         generated_id = str(uuid.uuid4())
         self.id = generated_id
         self.system_profile["id"] = generated_id
+        # set this now and not at commit time. It is needed as the fallback value for captured_on.
+        self.created_on = datetime.utcnow()
         self.captured_on = self._get_captured_date()
 
     def _get_captured_date(self):

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -9,7 +9,7 @@ psql 'postgresql://insights:insights@localhost:5432' -c 'create database testdb;
 
 BASELINE_DB_NAME=testdb FLASK_APP=historical_system_profiles.app:get_flask_app_with_migration flask db upgrade
 
-BASELINE_DB_NAME=testdb prometheus_multiproc_dir=$TEMPDIR nosetests -sx --with-coverage --cover-package historical_system_profiles  --cover-min-percentage 59 --cover-erase && rm -rf $TEMPDIR
+BASELINE_DB_NAME=testdb prometheus_multiproc_dir=$TEMPDIR nosetests -sx --with-coverage --cover-package historical_system_profiles  --cover-min-percentage 75 --cover-erase && rm -rf $TEMPDIR
 
 result=$?
 

--- a/tests/test_db_interface.py
+++ b/tests/test_db_interface.py
@@ -1,0 +1,43 @@
+import json
+
+from historical_system_profiles import db_interface
+
+from . import fixtures
+from . import utils
+
+
+class DBInterfaceTests(utils.ApiTest):
+    def test_save_model(self):
+        # confirm there are zero records to start
+        response = self.client.get(
+            "/api/historical-system-profiles/v1/systems/29dbe6ce-897f-11ea-8f75-98fa9b07d419",
+            headers=fixtures.AUTH_HEADER,
+        )
+        data = json.loads(response.data)
+        self.assertEquals(0, len(data["data"][0]["profiles"]))
+
+        # add one record, confirm count
+        with self.test_flask_app.app_context():
+            db_interface.create_profile(
+                "29dbe6ce-897f-11ea-8f75-98fa9b07d419", {}, "1234"
+            )
+
+        response = self.client.get(
+            "/api/historical-system-profiles/v1/systems/29dbe6ce-897f-11ea-8f75-98fa9b07d419",
+            headers=fixtures.AUTH_HEADER,
+        )
+        data = json.loads(response.data)
+        self.assertEquals(1, len(data["data"][0]["profiles"]))
+
+        # delete all records, confirm count
+        with self.test_flask_app.app_context():
+            db_interface.delete_hsps_by_inventory_id(
+                "29dbe6ce-897f-11ea-8f75-98fa9b07d419"
+            )
+
+        response = self.client.get(
+            "/api/historical-system-profiles/v1/systems/29dbe6ce-897f-11ea-8f75-98fa9b07d419",
+            headers=fixtures.AUTH_HEADER,
+        )
+        data = json.loads(response.data)
+        self.assertEquals(0, len(data["data"][0]["profiles"]))

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -1,36 +1,10 @@
 import json
 
-from historical_system_profiles import app
-
-import unittest
-import mock
-from mock import patch
 from . import fixtures
+from . import utils
 
 
-class ApiTest(unittest.TestCase):
-    def setUp(self):
-        self.rbac_patcher = patch(
-            "historical_system_profiles.views.v1.view_helpers.ensure_has_role"
-        )
-        patched_rbac = self.rbac_patcher.start()
-        patched_rbac.return_value = None  # validate all RBAC requests
-        self.addCleanup(self.stopPatches)
-        test_connexion_app = app.create_app()
-        test_flask_app = test_connexion_app.app
-        self.client = test_flask_app.test_client()
-        self.rbac_patcher = mock.patch(
-            "historical_system_profiles.views.v1.view_helpers.ensure_has_role"
-        )
-        patched_rbac = self.rbac_patcher.start()
-        patched_rbac.return_value = None  # validate all RBAC requests
-        self.addCleanup(self.stopPatches)
-
-    def stopPatches(self):
-        self.rbac_patcher.stop()
-
-
-class HSPApiTests(ApiTest):
+class HSPApiTests(utils.ApiTest):
     def test_status_bad_uuid(self):
         response = self.client.get(
             "/api/historical-system-profiles/v1/profiles/1",

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,22 @@
+from historical_system_profiles import app
+
+import unittest
+import mock
+
+
+class ApiTest(unittest.TestCase):
+    def setUp(self):
+        self.rbac_patcher = mock.patch(
+            "historical_system_profiles.views.v1.view_helpers.ensure_has_role"
+        )
+        patched_rbac = self.rbac_patcher.start()
+        patched_rbac.return_value = None  # validate all RBAC requests
+
+        self.addCleanup(self.stopPatches)
+
+        test_connexion_app = app.create_app()
+        self.test_flask_app = test_connexion_app.app
+        self.client = self.test_flask_app.test_client()
+
+    def stopPatches(self):
+        self.rbac_patcher.stop()


### PR DESCRIPTION
Previously, we were relying on the ORM to set the `created_on`
timestamp if one was not provided via `captured_on`. This happens
during object save, but we needed it earlier than that.

This commit sets `created_on` early in the `__init__` so it can be
referenced later.