### PR TITLE
expose record cleaner metrics

### DIFF
--- a/clean_expired_records.py
+++ b/clean_expired_records.py
@@ -3,16 +3,19 @@ import time
 from historical_system_profiles import config, listener_logging
 from historical_system_profiles.app import create_app
 from historical_system_profiles import db_interface
+from historical_system_profiles import listener_metrics as metrics
+from prometheus_client import start_http_server as start_metrics_server
 
 
 def main():
     logger = listener_logging.initialize_logging()
-    logger.error(
+    start_metrics_server(config.listener_metrics_port)
+    app = create_app()
+    logger.warn(
         "starting expired record cleaning loop, will remove records older than "
         "%s days every %s minutes"
         % (config.valid_profile_age_days, config.expired_cleaner_sleep_minutes)
     )
-    app = create_app()
     expired_record_cleaning_loop(app.app, logger)
 
 
@@ -24,6 +27,7 @@ def expired_record_cleaning_loop(flask_app, logger):
                     config.valid_profile_age_days
                 )
                 logger.info("deleted %s expired records" % deleted_count)
+                metrics.records_cleaned.inc(deleted_count)
             except Exception:
                 logger.exception(
                     "An error occurred during expired record cleaning loop"

--- a/historical_system_profiles/listener_metrics.py
+++ b/historical_system_profiles/listener_metrics.py
@@ -27,3 +27,5 @@ delete_messages_errored = Counter(
     "hsp_delete_messages_errored",
     "count of delete messages we unsuccessfully processed",
 )
+
+records_cleaned = Counter("hsp_records_cleaned", "count of records removed by cleaner")


### PR DESCRIPTION
This commit exposes metrics on port 5000 for the expired record
cleaner.  It also tracks the number of expired records that were
removed in each run.