### PR TITLE
disable log group creation

### DIFF
--- a/historical_system_profiles/listener_logging.py
+++ b/historical_system_profiles/listener_logging.py
@@ -22,6 +22,7 @@ def config_cloudwatch(logger):
         boto3_session=CW_SESSION,
         log_group=config.log_group,
         stream_name=config.namespace,
+        create_log_group=False,
     )
     cw_handler.setFormatter(LogstashFormatterV1())
     logger.addHandler(cw_handler)


### PR DESCRIPTION
We should not be creating log groups, per platform team.