### PR TITLE
override pipenv version in s2i

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+function is_django_installed() {
+  python -c "import django" &>/dev/null
+}
+
+function should_collectstatic() {
+  is_django_installed && [[ -z "$DISABLE_COLLECTSTATIC" ]]
+}
+
+function virtualenv_bin() {
+  if head "/etc/redhat-release" | grep -q "^CentOS Linux release 7" || \
+     head "/etc/redhat-release" | grep -q "^Red Hat Enterprise Linux\( Server\)\? release 7" || \
+     head "/etc/redhat-release" | grep -q "^Fedora release"; then
+    virtualenv $1
+  else
+    virtualenv-${PYTHON_VERSION} $1
+  fi
+}
+
+# Install pipenv or micropipenv to the separate virtualenv to isolate it
+# from system Python packages and packages in the main
+# virtualenv. Executable is simlinked into ~/.local/bin
+# to be accessible. This approach is inspired by pipsi
+# (pip script installer).
+function install_tool() {
+  echo "---> Installing $1 packaging tool ..."
+  VENV_DIR=$HOME/.local/venvs/$1
+  virtualenv_bin "$VENV_DIR"
+  $VENV_DIR/bin/pip --isolated install -U $1$2  # Combines package name with [extras] if [extras] is defined as $2
+  mkdir -p $HOME/.local/bin
+  ln -s $VENV_DIR/bin/$1 $HOME/.local/bin/$1
+}
+
+function install_pipenv() {
+  echo "---> Installing $1 tool ..."
+  VENV_DIR=$HOME/.local/venvs/$1
+  virtualenv_bin "$VENV_DIR"
+  $VENV_DIR/bin/pip --isolated install "pipenv==2018.11.26" --ignore-installed
+  mkdir -p $HOME/.local/bin
+  ln -s $VENV_DIR/bin/$1 $HOME/.local/bin/$1
+}
+
+set -e
+
+# First of all, check that we don't have disallowed combination of ENVs
+if [[ ! -z "$ENABLE_PIPENV" && ! -z "$ENABLE_MICROPIPENV" ]]; then
+  echo "ERROR: Pipenv and micropipenv cannot be enabled at the same time!"
+  # podman/buildah does not relay this exit code but it will be fixed hopefuly
+  # https://github.com/containers/buildah/issues/2305
+  exit 3
+fi
+
+shopt -s dotglob
+echo "---> Installing application source ..."
+mv /tmp/src/* "$HOME"
+
+# set permissions for any installed artifacts
+fix-permissions /opt/app-root -P
+
+# We have to first upgrade pip to at least 19.3 because:
+# * pip < 9 does not support different packages' versions for Python 2/3
+# * pip < 19.3 does not support manylinux2014 wheels. Only manylinux2014 wheels
+#   support platforms like ppc64le, aarch64 or armv7
+echo "---> Upgrading pip to version 19.3.1 ..."
+pip install -U "pip==19.3.1"
+
+if [[ ! -z "$UPGRADE_PIP_TO_LATEST" ]]; then
+  echo "---> Upgrading pip to latest version ..."
+  pip install -U pip setuptools wheel
+fi
+
+if [[ ! -z "$ENABLE_PIPENV" ]]; then
+  install_pipenv "pipenv"
+  echo "---> $(pipenv --version)"
+  echo "---> Installing dependencies via pipenv ..."
+  if [[ -f Pipfile ]]; then
+    pipenv install --deploy
+  elif [[ -f requirements.txt ]]; then
+    pipenv install -r requirements.txt
+  fi
+  # pipenv check
+elif [[ ! -z "$ENABLE_MICROPIPENV" ]]; then
+  install_tool "micropipenv" "[toml]"
+  echo "---> Installing dependencies via micropipenv ..."
+  # micropipenv detects Pipfile.lock and requirements.txt in this order
+  micropipenv install --deploy
+elif [[ -f requirements.txt ]]; then
+  echo "---> Installing dependencies ..."
+  pip install -r requirements.txt
+fi
+
+if [[ -f setup.py && -z "$DISABLE_SETUP_PY_PROCESSING" ]]; then
+  echo "---> Installing application ..."
+  pip install .
+fi
+
+if should_collectstatic; then
+  (
+    echo "---> Collecting Django static files ..."
+
+    APP_HOME=$(readlink -f "${APP_HOME:-.}")
+    # Change the working directory to APP_HOME
+    PYTHONPATH="$(pwd)${PYTHONPATH:+:$PYTHONPATH}"
+    cd "$APP_HOME"
+
+    # Look for 'manage.py' in the current directory
+    manage_file=./manage.py
+
+    if [[ ! -f "$manage_file" ]]; then
+      echo "WARNING: seems that you're using Django, but we could not find a 'manage.py' file."
+      echo "'manage.py collectstatic' ignored."
+      exit
+    fi
+
+    if ! python $manage_file collectstatic --dry-run --noinput &> /dev/null; then
+      echo "WARNING: could not run 'manage.py collectstatic'. To debug, run:"
+      echo "    $ python $manage_file collectstatic --noinput"
+      echo "Ignore this warning if you're not serving static files with Django."
+      exit
+    fi
+
+    python $manage_file collectstatic --noinput
+  )
+fi
+
+# set permissions for any installed artifacts
+fix-permissions /opt/app-root -P

--- a/.s2i/bin/init-wrapper
+++ b/.s2i/bin/init-wrapper
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Overview of how this script works: http://veithen.io/2014/11/16/sigterm-propagation.html
+# Set a trap to kill the main app process when this
+# init script receives SIGTERM or SIGINT
+trap 'kill -s TERM $PID' TERM INT
+# Execute the main application in the background
+"$@" &
+PID=$!
+# wait command always terminates when trap is caught, even if the process hasn't finished yet
+wait $PID
+# Remove the trap and wait till the app process finishes completely
+trap - TERM INT
+# We wait again, since the first wait terminates when trap is caught
+wait $PID
+# Exit with the exit code of the app process
+STATUS=$?
+exit $STATUS

--- a/.s2i/bin/run
+++ b/.s2i/bin/run
@@ -1,0 +1,116 @@
+#!/bin/bash
+source /opt/app-root/etc/generate_container_user
+
+set -e
+
+function is_gunicorn_installed() {
+  hash gunicorn &>/dev/null
+}
+
+function is_django_installed() {
+  python -c "import django" &>/dev/null
+}
+
+function should_migrate() {
+  is_django_installed && [[ -z "$DISABLE_MIGRATE" ]]
+}
+
+# Guess the number of workers according to the number of cores
+function get_default_web_concurrency() {
+  limit_vars=$(cgroup-limits)
+  local $limit_vars
+  if [ -z "${NUMBER_OF_CORES:-}" ]; then
+    echo 1
+    return
+  fi
+
+  local max=$((NUMBER_OF_CORES*2))
+  # Require at least 43 MiB and additional 40 MiB for every worker
+  local default=$(((${MEMORY_LIMIT_IN_BYTES:-MAX_MEMORY_LIMIT_IN_BYTES}/1024/1024 - 43) / 40))
+  default=$((default > max ? max : default))
+  default=$((default < 1 ? 1 : default))
+  # According to http://docs.gunicorn.org/en/stable/design.html#how-many-workers,
+  # 12 workers should be enough to handle hundreds or thousands requests per second
+  default=$((default > 12 ? 12 : default))
+  echo $default
+}
+
+function maybe_run_in_init_wrapper() {
+  if [[ -z "$ENABLE_INIT_WRAPPER" ]]; then
+    exec "$@"
+  else
+    exec $STI_SCRIPTS_PATH/init-wrapper "$@"
+  fi
+}
+
+APP_HOME=$(readlink -f "${APP_HOME:-.}")
+# Change the working directory to APP_HOME
+PYTHONPATH="$(pwd)${PYTHONPATH:+:$PYTHONPATH}"
+cd "$APP_HOME"
+
+app_script_check="${APP_SCRIPT-}"
+APP_SCRIPT="${APP_SCRIPT-app.sh}"
+if [[ -f "$APP_SCRIPT" ]]; then
+  echo "---> Running application from script ($APP_SCRIPT) ..."
+  if [[ "$APP_SCRIPT" != /* ]]; then
+    APP_SCRIPT="./$APP_SCRIPT"
+  fi
+  maybe_run_in_init_wrapper "$APP_SCRIPT"
+else
+  test -n "$app_script_check" && (>&2 echo "ERROR: file '$app_script_check' not found.") && exit 1
+fi
+
+app_file_check="${APP_FILE-}"
+APP_FILE="${APP_FILE-app.py}"
+if [[ -f "$APP_FILE" ]]; then
+  echo "---> Running application from Python script ($APP_FILE) ..."
+  maybe_run_in_init_wrapper python "$APP_FILE"
+else
+  test -n "$app_file_check" && (>&2 echo "ERROR: file '$app_file_check' not found.") && exit 1
+fi
+
+# Look for 'manage.py' in the current directory
+manage_file=./manage.py
+
+if should_migrate; then
+  if [[ -f "$manage_file" ]]; then
+    echo "---> Migrating database ..."
+    python "$manage_file" migrate --noinput
+  else
+    echo "WARNING: seems that you're using Django, but we could not find a 'manage.py' file."
+    echo "Skipped 'python manage.py migrate'."
+  fi
+fi
+
+if is_gunicorn_installed; then
+  setup_py=$(find "$HOME" -maxdepth 2 -type f -name 'setup.py' -print -quit)
+  # Look for wsgi module in the current directory
+  if [[ -z "$APP_MODULE" && -f "./wsgi.py" ]]; then
+    APP_MODULE=wsgi
+  elif [[ -z "$APP_MODULE" && -f "$setup_py" ]]; then
+    APP_MODULE="$(python "$setup_py" --name)"
+  fi
+
+  if [[ "$APP_MODULE" ]]; then
+    export WEB_CONCURRENCY=${WEB_CONCURRENCY:-$(get_default_web_concurrency)}
+
+    echo "---> Serving application with gunicorn ($APP_MODULE) ..."
+    exec gunicorn "$APP_MODULE" --bind=0.0.0.0:8080 --access-logfile=- --config "$APP_CONFIG"
+  fi
+fi
+
+if is_django_installed; then
+  if [[ -f "$manage_file" ]]; then
+    echo "---> Serving application with 'manage.py runserver' ..."
+    echo "WARNING: this is NOT a recommended way to run you application in production!"
+    echo "Consider using gunicorn or some other production web server."
+    maybe_run_in_init_wrapper python "$manage_file" runserver 0.0.0.0:8080
+  else
+    echo "WARNING: seems that you're using Django, but we could not find a 'manage.py' file."
+    echo "Skipped 'python manage.py runserver'."
+  fi
+fi
+
+>&2 echo "ERROR: don't know how to run your application."
+>&2 echo "Please set either APP_MODULE, APP_FILE or APP_SCRIPT environment variables, or create a file 'app.py' to launch your application."
+exit 1

--- a/.s2i/bin/usage
+++ b/.s2i/bin/usage
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+DISTRO=`cat /etc/*-release | grep ^ID= | grep -Po '".*?"' | tr -d '"'`
+NAMESPACE=centos
+[[ $DISTRO =~ rhel* ]] && NAMESPACE=rhscl
+
+cat <<EOF
+This is a S2I python-3.6 ${DISTRO} base image:
+To use it, install S2I: https://github.com/openshift/source-to-image
+
+Sample invocation:
+
+s2i build https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/ ${NAMESPACE}/python-36-${DISTRO}7 python-sample-app
+
+
+You can then run the resulting image via:
+podman run -p 8080:8080 python-sample-app
+EOF


### PR DESCRIPTION
Upstream s2i does not allow setting the pipenv version. This commit
pins us to 2018.11.24, which is the last known working version.

This should be a temporary thing until upstream pipenv is updated.