### PR TITLE
allow kafka poll tuning

### DIFF
--- a/historical_system_profiles/config.py
+++ b/historical_system_profiles/config.py
@@ -45,3 +45,5 @@ expired_cleaner_sleep_minutes = float(os.getenv("EXPIRED_CLEANER_SLEEP_MINUTES",
 tracker_topic = os.getenv("TRACKER_TOPIC", "platform.payload-status")
 listener_metrics_port = int(os.getenv("LISTENER_METRICS_PORT", 5000))
 listener_delay = int(os.getenv("LISTENER_DELAY", 5))
+kafka_max_poll_interval_ms = int(os.getenv("KAFKA_MAX_POLL_INTERVAL_MS", 300000))
+kafka_max_poll_records = int(os.getenv("KAFKA_MAX_POLL_RECORDS", 500))

--- a/kafka_listener.py
+++ b/kafka_listener.py
@@ -31,6 +31,10 @@ def main():
 
 def init_consumer(queue, logger):
     logger.info("creating consumer with kafka_group_id %s" % config.kafka_group_id)
+    logger.info(
+        "kafka max poll interval (msec): %s" % config.kafka_max_poll_interval_ms
+    )
+    logger.info("kafka max poll records: %s" % config.kafka_max_poll_records)
     consumer = KafkaConsumer(
         queue,
         bootstrap_servers=config.bootstrap_servers,
@@ -38,6 +42,8 @@ def init_consumer(queue, logger):
         value_deserializer=lambda m: json.loads(m.decode("utf-8")),
         retry_backoff_ms=1000,
         consumer_timeout_ms=200,
+        max_poll_interval_ms=config.kafka_max_poll_interval_ms,
+        max_poll_records=config.kafka_max_poll_records,
     )
     return consumer
 


### PR DESCRIPTION
Previously, we used the kafka poll defaults for the number of records
to pull (500), and how long to wait to process said records (5 min).

This seems to work fine for archive processing but does not work for
deletes. Deleting 500 inventory IDs can take longer than 5 minutes in
some cases. When this happens, our kafka client times out and puts the
delete messages back on the queue for reprocessing. This can result in
a pile-up of messages since we are unsuccessfully reprocessing the
same messages over and over.

This commit exposes two options: `KAFKA_MAX_POLL_INTERVAL_MS` (default
5 min) and `KAFKA_MAX_POLL_RECORDS` (default 500). We also now log the
  values for these at startup.