### PR TITLE
do not save multiple profiles with the same date

### DIFF
--- a/historical_system_profiles/archiver.py
+++ b/historical_system_profiles/archiver.py
@@ -24,6 +24,16 @@ def _record_success_message(host, request_id, ptc):
     )
 
 
+def _record_duplicate_message(host, request_id, ptc):
+    metrics.profile_messages_processed_duplicates.inc()
+    ptc.emit_success_message(
+        "profile not saved to db (timestamp already exists)",
+        request_id=request_id,
+        account=host["account"],
+        inventory_id=host["id"],
+    )
+
+
 def _archive_profile(data, ptc, logger):
     """
     given an event, archive a profile and emit a success message
@@ -35,12 +45,34 @@ def _archive_profile(data, ptc, logger):
     profile = host["system_profile"]
     # fqdn is on the host but we need it in the profile as well
     profile["fqdn"] = host["fqdn"]
-    db_interface.create_profile(
-        inventory_id=host["id"], profile=profile, account_number=host["account"],
-    )
 
-    _record_success_message(host, request_id, ptc)
-    logger.info("wrote inventory_id %s's profile to historical database" % host["id"])
+    captured_date = profile.get("captured_date")
+    account = host["account"]
+
+    # Historical profiles have a "captured_date" which is when the data was
+    # taken from the system by insights-client. However, some reporters to
+    # inventory service run in a batch mode and do not update the
+    # captured_date. The logic below will only save a profile if the
+    # captured_date is one that we don't already have for the system in
+    # question.  This works for our purposes since users differentiate between
+    # profiles in the app via captured_date.
+
+    if captured_date and db_interface.is_profile_recorded(
+        captured_date, host["id"], account
+    ):
+        logger.info(
+            "profile with date %s is already recorded for %s"
+            % (captured_date, host["id"])
+        )
+        _record_duplicate_message(host, request_id, ptc)
+    else:
+        db_interface.create_profile(
+            inventory_id=host["id"], profile=profile, account_number=account,
+        )
+        logger.info(
+            "wrote inventory_id %s's profile to historical database" % host["id"]
+        )
+        _record_success_message(host, request_id, ptc)
 
 
 def _emit_archiver_error(data, ptc, logger):

--- a/historical_system_profiles/db_interface.py
+++ b/historical_system_profiles/db_interface.py
@@ -42,6 +42,25 @@ def get_hsps_by_inventory_id(inventory_id, account_number):
     return query_results
 
 
+def is_profile_recorded(captured_date, inventory_id, account_number):
+    """
+    returns True if an existing system profile exists with the same
+    captured date + inventory id + account number.
+
+    This could possibly be enforced in the DB schema. I'm doing it here for now
+    so we have more flexbility if we want to change the rules on this later.
+    """
+    query = HistoricalSystemProfile.query.filter(
+        HistoricalSystemProfile.account == account_number,
+        HistoricalSystemProfile.inventory_id == inventory_id,
+        HistoricalSystemProfile.captured_on == captured_date,
+    )
+
+    if query.first():
+        return True
+    return False
+
+
 @rollback_on_exception
 def delete_hsps_by_inventory_id(inventory_id):
     query = HistoricalSystemProfile.query.filter(

--- a/historical_system_profiles/listener_metrics.py
+++ b/historical_system_profiles/listener_metrics.py
@@ -9,6 +9,12 @@ profile_messages_processed = Counter(
     "count of profile messages we successfully processed",
 )
 
+profile_messages_processed_duplicates = Counter(
+    "hsp_profile_messages_processed_duplicates",
+    "count of profile messages that were already in the database",
+)
+
+
 profile_messages_errored = Counter(
     "hsp_profile_messages_errored",
     "count of profile messages we unsuccessfully processed",


### PR DESCRIPTION
If a reporter updates an inventory record, it will fire an "updated
record" message on the egress topic. However, not all of these updates
actually update the system profile. This results in duplicate system
profiles in the historical DB.

This change to the archiver checks to ensure a record does not already
exist before saving it to the DB.

We could do this more elegantly via a DB uniqueness constraint;
however this way does not require a data migration to clean old
records. We may eventually want to add a constraint once the data is
unique.

Note that this does not do the select and insert in the same
transaction.  I don't anticipate issues arising from this since the
"fail" case (which should be rare) is that we insert two records which
is the current behavior.  Adding a constraint would also let us avoid
having to add a transaction with a select and insert.