### PR TITLE
add index on inventory_id

### DIFF
--- a/historical_system_profiles/models.py
+++ b/historical_system_profiles/models.py
@@ -14,7 +14,7 @@ class HistoricalSystemProfile(db.Model):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     account = db.Column(db.String(10))
-    inventory_id = db.Column(UUID(as_uuid=True))
+    inventory_id = db.Column(UUID(as_uuid=True), index=True)
     created_on = db.Column(db.DateTime, default=datetime.utcnow)
     modified_on = db.Column(
         db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow

--- a/migrations/versions/9b6b2ca8d235_.py
+++ b/migrations/versions/9b6b2ca8d235_.py
@@ -1,0 +1,31 @@
+"""add inventory_id index
+
+Revision ID: 9b6b2ca8d235
+Revises: 6c97901967f3
+Create Date: 2020-06-19 08:24:01.039562
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "9b6b2ca8d235"
+down_revision = "6c97901967f3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(
+        op.f("ix_historical_system_profiles_inventory_id"),
+        "historical_system_profiles",
+        ["inventory_id"],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(
+        op.f("ix_historical_system_profiles_inventory_id"),
+        table_name="historical_system_profiles",
+    )


### PR DESCRIPTION
When we added the check for duplicate IDs + captured_dates, we ended
up throwing a lot of seqential scans at the database. For example, a
single query for a particular ID + date took around 500 msec.

This commit adds an index on inventory_id. After adding, a query in my
environment went from 5.475 ms to 0.042 ms.