### PR TITLE
logging fixups for archiver

### DIFF
--- a/historical_system_profiles/config.py
+++ b/historical_system_profiles/config.py
@@ -8,15 +8,6 @@ app_name = os.getenv("APP_NAME", "historical-system-profiles")
 logger = logging.getLogger(app_name)
 
 
-def get_namespace():
-    try:
-        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
-            namespace = f.read()
-        return namespace
-    except EnvironmentError:
-        logger.info("Not running in openshift")
-
-
 # please ensure these are all documented in README.md
 _db_user = os.getenv("HSP_DB_USER", "insights")
 _db_password = os.getenv("HSP_DB_PASS", "insights")
@@ -38,7 +29,7 @@ aws_secret_access_key = os.getenv("CW_AWS_SECRET_ACCESS_KEY", None)
 aws_region_name = os.getenv("CW_AWS_REGION_NAME", "us-east-1")
 log_group = os.getenv("CW_LOG_GROUP", "platform-dev")
 log_sql_statements = str_to_bool(os.getenv("LOG_SQL_STATEMENTS", "False"))
-namespace = get_namespace()
+hostname = os.getenv("HOSTNAME", "hsp-hostname-not-set")
 
 valid_profile_age_days = float(os.getenv("VALID_PROFILE_AGE_DAYS", 7.0))
 expired_cleaner_sleep_minutes = float(os.getenv("EXPIRED_CLEANER_SLEEP_MINUTES", 20.0))

--- a/historical_system_profiles/listener_logging.py
+++ b/historical_system_profiles/listener_logging.py
@@ -21,7 +21,7 @@ def config_cloudwatch(logger):
     cw_handler = watchtower.CloudWatchLogHandler(
         boto3_session=CW_SESSION,
         log_group=config.log_group,
-        stream_name=config.namespace,
+        stream_name=config.hostname,
         create_log_group=False,
     )
     cw_handler.setFormatter(LogstashFormatterV1())


### PR DESCRIPTION
We did not log the HSP ID or captured date previously. Additionally, we
were calling cloudwatch incorrectly by using the project name as the
stream name, and some logs were being dropped. Each pod's stream needs a
unique name.