### PR TITLE
use new inventory topic

### DIFF
--- a/historical_system_profiles/archiver.py
+++ b/historical_system_profiles/archiver.py
@@ -38,6 +38,10 @@ def _archive_profile(data, ptc, logger):
     """
     given an event, archive a profile and emit a success message
     """
+    if data.value["type"] not in ("created", "updated"):
+        logger.info("skipping message that is not created or updated type")
+        return
+
     host = data.value["host"]
     request_id = data.value["platform_metadata"].get("request_id")
     _record_recv_message(host, request_id, ptc)
@@ -68,9 +72,6 @@ def _archive_profile(data, ptc, logger):
     else:
         hsp = db_interface.create_profile(
             inventory_id=host["id"], profile=profile, account_number=host["account"],
-        )
-        logger.info(
-            "wrote inventory_id %s's profile to historical database" % host["id"]
         )
         _record_success_message(hsp.id, host, request_id, ptc)
         logger.info(

--- a/kafka_listener.py
+++ b/kafka_listener.py
@@ -19,22 +19,22 @@ def main():
     app = create_app()
     ptc = payload_tracker_interface.PayloadTrackerClient(logger)
 
+    consumer = init_consumer("platform.inventory.events", logger)
+
     if config.listener_type == "ARCHIVER":
-        consumer = init_consumer("platform.inventory.host-egress", logger)
         archiver.event_loop(app.app, consumer, ptc, logger, config.listener_delay)
     elif config.listener_type == "DELETER":
-        consumer = init_consumer("platform.inventory.events", logger)
         deleter.event_loop(app.app, consumer, ptc, logger, config.listener_delay)
     else:
         logger.error("unable to detect listener type")
 
 
 def init_consumer(queue, logger):
-    logger.info("creating consumer with kafka_group_id %s" % config.kafka_group_id)
     logger.info(
-        "kafka max poll interval (msec): %s" % config.kafka_max_poll_interval_ms
+        f"creating consumer of {queue} with kafka_group_id {config.kafka_group_id}"
     )
-    logger.info("kafka max poll records: %s" % config.kafka_max_poll_records)
+    logger.info(f"kafka max poll interval (msec): {config.kafka_max_poll_interval_ms}")
+    logger.info(f"kafka max poll records: {config.kafka_max_poll_records}")
     consumer = KafkaConsumer(
         queue,
         bootstrap_servers=config.bootstrap_servers,

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -88,7 +88,7 @@ FETCH_SYSTEMS_WITH_PROFILES_RESULT = (
     },
 )
 
-EGRESS_MESSAGE_VALUE = {
+EVENT_MESSAGE_VALUE = {
     "host": {
         "account": "5432",
         "id": "6388350e-b18d-11ea-ad7f-98fa9b07d419",
@@ -96,4 +96,5 @@ EGRESS_MESSAGE_VALUE = {
         "system_profile": {"captured_date": "2020-06-18T17:11:05+00:00"},
     },
     "platform_metadata": {"request_id": "123456"},
+    "type": "created",
 }

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -9,7 +9,7 @@ from mock import MagicMock
 class ArchiverTests(utils.ApiTest):
     def test_archive_profile(self):
         message = MagicMock()
-        message.value = fixtures.EGRESS_MESSAGE_VALUE
+        message.value = fixtures.EVENT_MESSAGE_VALUE
         with self.test_flask_app.app_context():
             # save the same profile twice on purpose
             archiver._archive_profile(message, MagicMock(), MagicMock())


### PR DESCRIPTION
We now use the same inventory  topic for both delete and archive
messages. Since we are now pulling both messages off the same topic,
we added an additional check on archive messages to ensure we are
processing messages of the correct type before proceeding.