### PR TITLE
DRFT-60 add secure kafka communication

### DIFF
--- a/historical_system_profiles/config.py
+++ b/historical_system_profiles/config.py
@@ -22,6 +22,8 @@ bootstrap_servers = os.getenv("BOOTSTRAP_SERVERS", "kafka:29092").split(",")
 consume_topic = os.getenv("CONSUME_TOPIC", None)
 listener_type = os.getenv("LISTENER_TYPE", "ARCHIVER")
 kafka_group_id = os.getenv("KAFKA_GROUP_ID", "hsp-%s" % listener_type.lower())
+enable_kafka_ssl = str_to_bool(os.getenv("ENABLE_KAFKA_SSL", "False"))
+kafka_ssl_cert = os.getenv("KAFKA_SSL_CERT", "/opt/certs/kafka-cacert")
 
 # logging params used outside of flask
 aws_access_key_id = os.getenv("CW_AWS_ACCESS_KEY_ID", None)

--- a/historical_system_profiles/payload_tracker_interface.py
+++ b/historical_system_profiles/payload_tracker_interface.py
@@ -12,10 +12,19 @@ class PayloadTrackerClient:
         self.producer = self._init_producer()
 
     def _init_producer(self):
-        producer = KafkaProducer(
-            bootstrap_servers=config.bootstrap_servers,
-            value_serializer=lambda x: json.dumps(x).encode("utf-8"),
-        )
+        if config.enable_kafka_ssl:
+            producer = KafkaProducer(
+                bootstrap_servers=config.bootstrap_servers,
+                value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+                security_protocol="SSL",
+                ssl_cafile=config.kafka_ssl_cert,
+                ssl_check_hostname=False,
+            )
+        else:
+            producer = KafkaProducer(
+                bootstrap_servers=config.bootstrap_servers,
+                value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+            )
         return producer
 
     def emit_received_message(self, message, **kwargs):

--- a/kafka_listener.py
+++ b/kafka_listener.py
@@ -35,16 +35,31 @@ def init_consumer(queue, logger):
     )
     logger.info(f"kafka max poll interval (msec): {config.kafka_max_poll_interval_ms}")
     logger.info(f"kafka max poll records: {config.kafka_max_poll_records}")
-    consumer = KafkaConsumer(
-        queue,
-        bootstrap_servers=config.bootstrap_servers,
-        group_id=config.kafka_group_id,
-        value_deserializer=lambda m: json.loads(m.decode("utf-8")),
-        retry_backoff_ms=1000,
-        consumer_timeout_ms=200,
-        max_poll_interval_ms=config.kafka_max_poll_interval_ms,
-        max_poll_records=config.kafka_max_poll_records,
-    )
+    if config.enable_kafka_ssl:
+        consumer = KafkaConsumer(
+            queue,
+            bootstrap_servers=config.bootstrap_servers,
+            group_id=config.kafka_group_id,
+            value_deserializer=lambda m: json.loads(m.decode("utf-8")),
+            retry_backoff_ms=1000,
+            consumer_timeout_ms=200,
+            max_poll_interval_ms=config.kafka_max_poll_interval_ms,
+            max_poll_records=config.kafka_max_poll_records,
+            security_protocol="SSL",
+            ssl_cafile=config.kafka_ssl_cert,
+            ssl_check_hostname=False,
+        )
+    else:
+        consumer = KafkaConsumer(
+            queue,
+            bootstrap_servers=config.bootstrap_servers,
+            group_id=config.kafka_group_id,
+            value_deserializer=lambda m: json.loads(m.decode("utf-8")),
+            retry_backoff_ms=1000,
+            consumer_timeout_ms=200,
+            max_poll_interval_ms=config.kafka_max_poll_interval_ms,
+            max_poll_records=config.kafka_max_poll_records,
+        )
     return consumer
 
 


### PR DESCRIPTION
This adds ENABLE_KAFKA_SSL and KAFKA_SSL_CERT env vars and if ENABLE_KAFKA_SSL is set to True, uses the specified cert to do TLS on kafka connection.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [x] Cryptographic Practices
- [ ] Error Handling and Logging
- [x] Data Protection
- [x] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
