### PR TITLE
[DRFT-252] Check for drift after system checkin

### DIFF
--- a/historical_system_profiles/archiver.py
+++ b/historical_system_profiles/archiver.py
@@ -2,6 +2,10 @@ import time
 
 from historical_system_profiles import db_interface
 from historical_system_profiles import listener_metrics as metrics
+from historical_system_profiles.baseline_service_interface import (
+    fetch_system_baseline_associations,
+)
+from historical_system_profiles.drift_service_interface import check_for_drift
 
 
 def _record_recv_message(host, request_id, ptc):
@@ -81,6 +85,40 @@ def _archive_profile(data, ptc, logger):
             "wrote %s to historical database (inv id: %s, captured_on: %s)"
             % (hsp.id, hsp.inventory_id, hsp.captured_on)
         )
+        # After the new hsp is saved, we need to check for any reason to alert via
+        # triggering a notification, i.e. if drift from any associated baselines has
+        # occurred.
+        _check_and_send_notifications(host["id"], "service_auth_key", logger)
+
+
+def _check_and_send_notifications(inventory_id, service_auth_key, logger):
+    # After the new hsp is saved, we need to check for any reason to alert Notifications
+    # First, check if this system id is associated with any baselines
+    # If yes, then for each baseline associated, call for a short-circuited comparison
+    # to see if the system has drifted from that baseline.
+    # If anything has changed, send a kafka message to trigger a notification.
+
+    baselines = fetch_system_baseline_associations(
+        inventory_id, service_auth_key, logger
+    )
+    # If yes, then for each baseline associated, call for a short-circuited comparison
+    # to see if the system has drifted from that baseline.
+    if baselines:
+        for baseline in baselines:
+            if check_for_drift(inventory_id, baseline["id"], service_auth_key, logger):
+                # If anything has changed, send a kafka message to trigger a notification.
+                _emit_notifications_signal(inventory_id, baseline["id"])
+
+
+def _emit_notifications_signal(inventory_id, baseline_id, data, ptc, logger):
+    """
+    send a data packet to payload tracker signalling Notifications app
+    that a system drifted from a baseline
+    """
+    logger.info(
+        "drift detected, signal sent for Notifications to send alert inv id: %s)"
+        % (inventory_id)
+    )
 
 
 def _get_request_id(data):

--- a/historical_system_profiles/archiver.py
+++ b/historical_system_profiles/archiver.py
@@ -42,6 +42,9 @@ def _archive_profile(data, ptc, logger):
     """
     given an event, archive a profile and emit a success message
     """
+
+    service_auth_key = data.value.get("platform_metadata", {}).get("b64_identity", None)
+
     if data.value["type"] not in ("created", "updated"):
         logger.info("skipping message that is not created or updated type")
         return
@@ -88,7 +91,7 @@ def _archive_profile(data, ptc, logger):
         # After the new hsp is saved, we need to check for any reason to alert via
         # triggering a notification, i.e. if drift from any associated baselines has
         # occurred.
-        _check_and_send_notifications(host["id"], "service_auth_key", logger)
+        _check_and_send_notifications(host["id"], service_auth_key, logger)
 
 
 def _check_and_send_notifications(inventory_id, service_auth_key, logger):

--- a/historical_system_profiles/archiver.py
+++ b/historical_system_profiles/archiver.py
@@ -110,7 +110,9 @@ def _check_and_send_notifications(inventory_id, service_auth_key, logger):
         for baseline_id in baseline_ids:
             if check_for_drift(inventory_id, baseline_id, service_auth_key, logger):
                 # If anything has changed, send a kafka message to trigger a notification.
-                _emit_notifications_signal(inventory_id, baseline_id, None, None, logger)
+                _emit_notifications_signal(
+                    inventory_id, baseline_id, None, None, logger
+                )
 
 
 def _emit_notifications_signal(inventory_id, baseline_id, data, ptc, logger):

--- a/historical_system_profiles/archiver.py
+++ b/historical_system_profiles/archiver.py
@@ -101,16 +101,16 @@ def _check_and_send_notifications(inventory_id, service_auth_key, logger):
     # to see if the system has drifted from that baseline.
     # If anything has changed, send a kafka message to trigger a notification.
 
-    baselines = fetch_system_baseline_associations(
+    baseline_ids = fetch_system_baseline_associations(
         inventory_id, service_auth_key, logger
     )
     # If yes, then for each baseline associated, call for a short-circuited comparison
     # to see if the system has drifted from that baseline.
-    if baselines:
-        for baseline in baselines:
-            if check_for_drift(inventory_id, baseline["id"], service_auth_key, logger):
+    if baseline_ids:
+        for baseline_id in baseline_ids:
+            if check_for_drift(inventory_id, baseline_id, service_auth_key, logger):
                 # If anything has changed, send a kafka message to trigger a notification.
-                _emit_notifications_signal(inventory_id, baseline["id"])
+                _emit_notifications_signal(inventory_id, baseline_id, None, None, logger)
 
 
 def _emit_notifications_signal(inventory_id, baseline_id, data, ptc, logger):

--- a/historical_system_profiles/baseline_service_interface.py
+++ b/historical_system_profiles/baseline_service_interface.py
@@ -1,0 +1,28 @@
+from urllib.parse import urljoin
+
+from historical_system_profiles import metrics
+from kerlescan import config
+from kerlescan.service_interface import fetch_data
+from kerlescan.constants import AUTH_HEADER_NAME, INTERNAL_BASELINE_SVC_ENDPOINT
+
+
+def fetch_system_baseline_associations(system_id, service_auth_key, logger):
+    """
+    call baseline systems association endpoint to get a list of baselines
+    this system is associated with
+    """
+
+    auth_header = {AUTH_HEADER_NAME: service_auth_key}
+
+    internal_baselines_location = urljoin(
+        config.baseline_svc_hostname, INTERNAL_BASELINE_SVC_ENDPOINT
+    )
+
+    return fetch_data(
+        internal_baselines_location,
+        auth_header,
+        system_id,
+        logger,
+        metrics.baseline_service_requests,
+        metrics.baseline_service_exceptions,
+    )

--- a/historical_system_profiles/baseline_service_interface.py
+++ b/historical_system_profiles/baseline_service_interface.py
@@ -20,7 +20,7 @@ def fetch_system_baseline_associations(system_id, service_auth_key, logger):
 
     query = "?system_id=%s" % system_id
     url = internal_baselines_location % query
-    result =  fetch_url(
+    result = fetch_url(
         url,
         auth_header,
         logger,

--- a/historical_system_profiles/baseline_service_interface.py
+++ b/historical_system_profiles/baseline_service_interface.py
@@ -2,7 +2,7 @@ from urllib.parse import urljoin
 
 from historical_system_profiles import metrics
 from kerlescan import config
-from kerlescan.service_interface import fetch_data
+from kerlescan.service_interface import fetch_url, internal_auth_header
 from kerlescan.constants import AUTH_HEADER_NAME, INTERNAL_BASELINE_SVC_ENDPOINT
 
 
@@ -12,17 +12,19 @@ def fetch_system_baseline_associations(system_id, service_auth_key, logger):
     this system is associated with
     """
 
-    auth_header = {AUTH_HEADER_NAME: service_auth_key}
+    auth_header = {**{AUTH_HEADER_NAME: service_auth_key}, **internal_auth_header()}
 
     internal_baselines_location = urljoin(
         config.baseline_svc_hostname, INTERNAL_BASELINE_SVC_ENDPOINT
     )
 
-    return fetch_data(
-        internal_baselines_location,
+    query = "?system_id=%s" % system_id
+    url = internal_baselines_location % query
+    result =  fetch_url(
+        url,
         auth_header,
-        system_id,
         logger,
         metrics.baseline_service_requests,
         metrics.baseline_service_exceptions,
     )
+    return result

--- a/historical_system_profiles/drift_service_interface.py
+++ b/historical_system_profiles/drift_service_interface.py
@@ -1,0 +1,33 @@
+from urllib.parse import urljoin
+
+from historical_system_profiles import listener_metrics as metrics
+from kerlescan import config
+from kerlescan.service_interface import fetch_url
+from kerlescan.constants import AUTH_HEADER_NAME, DRIFT_SVC_ENDPOINT
+
+
+def check_for_drift(system_id, baseline_id, service_auth_key, logger):
+    """
+    Call short-circuited comparison to check for any changes from baseline
+    """
+
+    auth_header = {AUTH_HEADER_NAME: service_auth_key}
+
+    drift_location = urljoin(config.drift_svc_hostname, DRIFT_SVC_ENDPOINT)
+
+    drift_url = str(
+        drift_location
+        + "?system_ids[]="
+        + system_id
+        + "&baseline_ids[]="
+        + baseline_id
+        + "&short_circuit=True"
+    )
+
+    return fetch_url(
+        drift_url,
+        auth_header,
+        logger,
+        metrics.drift_service_requests,
+        metrics.drift_service_exceptions,
+    )

--- a/historical_system_profiles/drift_service_interface.py
+++ b/historical_system_profiles/drift_service_interface.py
@@ -16,11 +16,7 @@ def check_for_drift(system_id, baseline_id, service_auth_key, logger):
     drift_location = urljoin(config.drift_svc_hostname, DRIFT_SVC_ENDPOINT)
 
     drift_url = str(
-        drift_location
-        + "?system_ids[]="
-        + system_id
-        + "&baseline_ids[]="
-        + baseline_id
+        drift_location + "?system_ids[]=" + system_id + "&baseline_ids[]=" + baseline_id
     )
 
     return fetch_url(

--- a/historical_system_profiles/drift_service_interface.py
+++ b/historical_system_profiles/drift_service_interface.py
@@ -1,8 +1,8 @@
 from urllib.parse import urljoin
 
-from historical_system_profiles import listener_metrics as metrics
+from historical_system_profiles import metrics
 from kerlescan import config
-from kerlescan.service_interface import fetch_url
+from kerlescan.service_interface import fetch_url, internal_auth_header
 from kerlescan.constants import AUTH_HEADER_NAME, DRIFT_SVC_ENDPOINT
 
 
@@ -11,7 +11,7 @@ def check_for_drift(system_id, baseline_id, service_auth_key, logger):
     Call short-circuited comparison to check for any changes from baseline
     """
 
-    auth_header = {AUTH_HEADER_NAME: service_auth_key}
+    auth_header = {**{AUTH_HEADER_NAME: service_auth_key}, **internal_auth_header()}
 
     drift_location = urljoin(config.drift_svc_hostname, DRIFT_SVC_ENDPOINT)
 
@@ -21,7 +21,6 @@ def check_for_drift(system_id, baseline_id, service_auth_key, logger):
         + system_id
         + "&baseline_ids[]="
         + baseline_id
-        + "&short_circuit=True"
     )
 
     return fetch_url(

--- a/historical_system_profiles/metrics.py
+++ b/historical_system_profiles/metrics.py
@@ -24,9 +24,7 @@ baseline_service_exceptions = Counter(
     "baseline_service_exceptions", "count of exceptions raised by baseline service"
 )
 
-drift_service_requests = Histogram(
-    "drift_service_requests", "drift service call stats"
-)
+drift_service_requests = Histogram("drift_service_requests", "drift service call stats")
 
 drift_service_exceptions = Counter(
     "drift_service_exceptions", "count of exceptions raised by drift service"

--- a/historical_system_profiles/metrics.py
+++ b/historical_system_profiles/metrics.py
@@ -15,3 +15,11 @@ inventory_exceptions = Counter(
 inventory_no_sysprofile = Histogram(
     "drift_systems_compared_no_sysprofile_UNUSED", "unused metric - do not use",
 )
+
+baseline_service_requests = Histogram(
+    "baselines_service_requests", "baseline service call stats"
+)
+
+baseline_service_exceptions = Counter(
+    "baseline_service_exceptions", "count of exceptions raised by baseline service"
+)

--- a/historical_system_profiles/metrics.py
+++ b/historical_system_profiles/metrics.py
@@ -23,3 +23,11 @@ baseline_service_requests = Histogram(
 baseline_service_exceptions = Counter(
     "baseline_service_exceptions", "count of exceptions raised by baseline service"
 )
+
+drift_service_requests = Histogram(
+    "drift_service_requests", "drift service call stats"
+)
+
+drift_service_exceptions = Counter(
+    "drift_service_exceptions", "count of exceptions raised by drift service"
+)


### PR DESCRIPTION
After archiving a new hsp, check for baselines associated with
this system, check for any drift from those baselines, and, if found,
emit signal to Notifications app via kafka to trigger alert.
The actual emit will take place in a follow-up PR with the kafka
portion of the work.## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
