### PR TITLE
[DRFT-885] Remove unused NodeJS package from base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ FROM registry.access.redhat.com/ubi8/python-38
 
 USER 0
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+    yum remove -y npm && \
     yum install -y hostname shared-mime-info && \
+    yum upgrade -y --security && \
     yum clean all -y
 
 COPY . /tmp/src


### PR DESCRIPTION
This PR removes NPM and its is dependencies including NodeJS, which are not used by drift-backend but their presence in the base image provides potential pathway for security vulnerabilities.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
