### PR TITLE
Wait two mins before starting probes

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -84,13 +84,13 @@ objects:
               httpGet:
                 path: /mgmt/v0/status
                 port: 8000
-              initialDelaySeconds: 10
+              initialDelaySeconds: 120
               periodSeconds: 10
             readinessProbe:
               httpGet:
                 path: /mgmt/v0/status
                 port: 8000
-              initialDelaySeconds: 10
+              initialDelaySeconds: 120
               periodSeconds: 10
             resources:
               limits:


### PR DESCRIPTION
`flask db upgrade` will wait for up to two minutes to establish a connection. If the liveness or readiness probe kills the pod before this timeout expires and prints an error, then ops will lack information about what went wrong.

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [ ] General Coding Practices
