### PR TITLE
Increased memory limits for requests

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -155,7 +155,7 @@ objects:
                 memory: 512Mi
               requests:
                 cpu: 250m
-                memory: 64Mi
+                memory: 256Mi
             volumes:
               - emptyDir: {}
                 name: historical-system-profiles-prometheus-data
@@ -222,7 +222,7 @@ objects:
                 memory: 1Gi
               requests:
                 cpu: 250m
-                memory: 64Mi
+                memory: 512Mi
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
             volumes:
@@ -295,7 +295,7 @@ objects:
                 memory: 1Gi
               requests:
                 cpu: 250m
-                memory: 64Mi
+                memory: 512Mi
               terminationMessagePath: /dev/termination-log
               terminationMessagePolicy: File
             volumes:


### PR DESCRIPTION
We need to increase memory limits to have working apps
in ephemeral environment which is used by pr checks.

Current memory limits in ephemeral are causing OOM kills of the workers.
Solution is to not remove apps resources in bonfire deploy command.
See https://github.com/RedHatInsights/historical-system-profiles-backend/pull/293
and https://github.com/RedHatInsights/system-baseline-backend/pull/316

Unfortunatelly these PRs means that hsps' non API services
does not comply with the MaxLimitRequestRatio in ephemeral env.

This will solve that :-)


## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
