### PR TITLE
[ESSNTL-5247] Store Inventory Group info with new HSP entry from Kafka message

### DIFF
--- a/historical_system_profiles/db_interface.py
+++ b/historical_system_profiles/db_interface.py
@@ -26,12 +26,13 @@ def rollback_on_exception(func):
 
 
 @rollback_on_exception
-def create_profile(inventory_id, profile, account_number, org_id):
+def create_profile(inventory_id, profile, account_number, org_id, groups=None):
     profile = HistoricalSystemProfile(
         account=account_number,
         org_id=org_id,
         inventory_id=inventory_id,
         system_profile=profile,
+        groups=groups,
     )
     db.session.add(profile)
     db.session.commit()

--- a/historical_system_profiles/models.py
+++ b/historical_system_profiles/models.py
@@ -24,11 +24,12 @@ class HistoricalSystemProfile(db.Model):
     captured_on = db.Column(db.DateTime, default=datetime.utcnow)
     groups = db.Column(JSONB)
 
-    def __init__(self, system_profile, inventory_id, account, org_id):
+    def __init__(self, system_profile, inventory_id, account, org_id, groups):
         self.inventory_id = inventory_id
         self.account = account
         self.system_profile = system_profile
         self.org_id = org_id
+        self.groups = groups
         # set the ID here so we can override the system profile's id with the historical profile
         generated_id = str(uuid.uuid4())
         self.id = generated_id

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -122,3 +122,22 @@ EVENT_MESSAGE_VALUE_WITHOUT_ACCOUNT = {
     "platform_metadata": {"request_id": "123456"},
     "type": "created",
 }
+
+EVENT_MESSAGE_VALUE_WITH_GROUPS = {
+    "host": {
+        "org_id": "5678",
+        "display_name": "9c033db1729c",
+        "id": "6388350e-b18d-11ea-ad7f-98fa9b07d419",
+        "insights_id": "cd9b8cda-607c-4359-9425-b6a0299a26a2",
+        "fqdn": "my-fqdn",
+        "updated": "2021-04-21T15:03:44.887439+00:00",
+        "tags": [],
+        "system_profile": {"captured_date": "2020-06-18T17:11:05+00:00"},
+        "groups": [
+            {"id": "40366ed4-19d8-4415-993e-1d430dc70ed7", "name": "group_1"},
+            {"id": "736bcb60-bbf5-4464-921f-1c431d76a124", "name": "group_2", "foo": "bar"},
+        ],
+    },
+    "platform_metadata": {"request_id": "123456"},
+    "type": "created",
+}

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -53,3 +53,47 @@ class ArchiverTests(utils.ApiTest):
         # cleanup
         with self.test_flask_app.app_context():
             db_interface.delete_hsps_by_inventory_id("6388350e-b18d-11ea-ad7f-98fa9b07d419")
+
+    @mock.patch("historical_system_profiles.archiver._check_and_send_notifications")
+    def test_archive_profile_with_groups(self, mock_check_and_send):
+        mock_check_and_send.return_value = None
+        message = MagicMock()
+        message.value = fixtures.EVENT_MESSAGE_VALUE_WITH_GROUPS
+        with self.test_flask_app.app_context():
+            # save the same profile twice on purpose
+            archiver._archive_profile(message, MagicMock(), MagicMock(), MagicMock())
+            archiver._archive_profile(message, MagicMock(), MagicMock(), MagicMock())
+
+        hsps = []
+        with self.test_flask_app.app_context():
+            hsps = db_interface.get_hsps_by_inventory_id(
+                "6388350e-b18d-11ea-ad7f-98fa9b07d419", None, "5678", "10", "0"
+            )
+
+        # ensure we didnt save the duplicate
+        self.assertEquals(1, len(hsps))
+
+        # ensure that the record contains groups data
+        # check the number of groups
+        groups = hsps[0].groups
+        self.assertEquals(2, len(groups))
+
+        # check that the groups are correct
+        ids = {group["id"] for group in groups}
+        self.assertEquals(
+            {"40366ed4-19d8-4415-993e-1d430dc70ed7", "736bcb60-bbf5-4464-921f-1c431d76a124"}, ids
+        )
+        names = {group["name"] for group in groups}
+        self.assertEquals({"group_2", "group_1"}, names)
+
+        # check that it doesn't store more than id and name
+        keys = set()
+        for dicts in groups:
+            for key in dicts:
+                keys.add(key)
+
+        self.assertEquals({"id", "name"}, keys)
+
+        # cleanup
+        with self.test_flask_app.app_context():
+            db_interface.delete_hsps_by_inventory_id("6388350e-b18d-11ea-ad7f-98fa9b07d419")


### PR DESCRIPTION
- Uses variables instead repeated hash access for readability
- Stores group information to hsps as it comes from Kafka

## Secure Coding Practices Checklist Link
- https://github.com/RedHatInsights/secure-coding-checklist

## Secure Coding Checklist
- [ ] Input Validation
- [ ] Output Encoding
- [ ] Authentication and Password Management
- [ ] Session Management
- [ ] Access Control
- [ ] Cryptographic Practices
- [ ] Error Handling and Logging
- [ ] Data Protection
- [ ] Communication Security
- [ ] System Configuration
- [ ] Database Security
- [ ] File Management
- [ ] Memory Management
- [x] General Coding Practices
